### PR TITLE
Implement minimal YKS tracker skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# yks
-yks
+# YKS Tracker
+
+Minimal web app to track YKS study progress. Backend is a FastAPI service using SQLite, frontend is React served as static files.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+Open `frontend/index.html` in a browser. The app will fetch data from the API.

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = 'sqlite:///./yks.db'
+
+engine = create_engine(
+    DATABASE_URL, connect_args={'check_same_thread': False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,126 @@
+from fastapi import FastAPI, HTTPException, Depends, Query
+from sqlalchemy.orm import Session
+from datetime import date
+from typing import List, Optional
+
+from .db import Base, engine, get_db
+from . import models
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+# Pydantic schemas
+from pydantic import BaseModel
+
+class TopicCreate(BaseModel):
+    name: str
+    parent_id: Optional[int] = None
+
+class SessionCreate(BaseModel):
+    date: date
+    topic_id: int
+    q_total: int
+    q_correct: int
+
+class StudyCreate(BaseModel):
+    date: date
+    topic_id: int
+    minutes: int
+
+
+class StatsResponse(BaseModel):
+    accuracy: Optional[float]
+    studyTime: int
+    progress: Optional[float]
+
+
+# Utility to build tree
+from collections import defaultdict
+
+def build_tree(topics: List[models.Topic]):
+    children = defaultdict(list)
+    lookup = {}
+    for t in topics:
+        lookup[t.id] = {"id": t.id, "name": t.name, "children": []}
+        children[t.parent_id].append(t.id)
+    def build(node_id):
+        node = lookup[node_id]
+        for child_id in children.get(node_id, []):
+            node["children"].append(build(child_id))
+        return node
+    return [build(cid) for cid in children[None]]
+
+
+@app.post('/topics')
+def create_topic(topic: TopicCreate, db: Session = Depends(get_db)):
+    t = models.Topic(name=topic.name, parent_id=topic.parent_id)
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return {"id": t.id, "name": t.name, "parent_id": t.parent_id}
+
+@app.get('/topics')
+def get_topics(db: Session = Depends(get_db)):
+    topics = db.query(models.Topic).all()
+    return build_tree(topics)
+
+@app.post('/sessions')
+def create_session(s: SessionCreate, db: Session = Depends(get_db)):
+    if s.q_correct > s.q_total:
+        raise HTTPException(400, 'q_correct cannot exceed q_total')
+    if s.date > date.today():
+        raise HTTPException(400, 'future date not allowed')
+    sess = models.Session(date=s.date, topic_id=s.topic_id,
+                         questions_total=s.q_total,
+                         questions_correct=s.q_correct)
+    db.add(sess)
+    db.commit()
+    db.refresh(sess)
+    return {"id": sess.id}
+
+@app.get('/sessions')
+def list_sessions(topic_id: int, from_date: date, to_date: date, db: Session = Depends(get_db)):
+    rows = db.query(models.Session).filter(
+        models.Session.topic_id == topic_id,
+        models.Session.date.between(from_date, to_date)
+    ).all()
+    return [
+        {"date": r.date, "q_total": r.questions_total, "q_correct": r.questions_correct}
+        for r in rows
+    ]
+
+@app.post('/study')
+def create_study(s: StudyCreate, db: Session = Depends(get_db)):
+    if s.date > date.today():
+        raise HTTPException(400, 'future date not allowed')
+    log = models.StudyLog(date=s.date, topic_id=s.topic_id, minutes=s.minutes)
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return {"id": log.id}
+
+@app.get('/stats')
+def get_stats(topic_id: int, from_date: date, to_date: date, db: Session = Depends(get_db)):
+    # gather subtree ids (simplified: only topic itself)
+    # TODO include descendants
+    base = db.query(models.Session).filter(
+        models.Session.topic_id == topic_id,
+        models.Session.date.between(from_date, to_date)
+    )
+    correct = sum(r.questions_correct for r in base)
+    total = sum(r.questions_total for r in base)
+
+    study = db.query(models.StudyLog).filter(
+        models.StudyLog.topic_id == topic_id,
+        models.StudyLog.date.between(from_date, to_date)
+    )
+    mins = sum(r.minutes for r in study)
+
+    accuracy = (correct / total) if total else None
+    # Progress is simple average for now
+    progress = None
+    if accuracy is not None:
+        progress = (accuracy + min(mins / 60.0, 1.0)) / 2  # TODO weighting
+
+    return StatsResponse(accuracy=accuracy, studyTime=mins, progress=progress)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, Text, Date, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+class Topic(Base):
+    __tablename__ = 'topic'
+    id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)
+    parent_id = Column(Integer, ForeignKey('topic.id'), nullable=True, index=True)
+    children = relationship('Topic')
+
+class Session(Base):
+    __tablename__ = 'session'
+    id = Column(Integer, primary_key=True)
+    date = Column(Date, nullable=False, index=True)
+    topic_id = Column(Integer, ForeignKey('topic.id'), nullable=False, index=True)
+    questions_total = Column(Integer, nullable=False)
+    questions_correct = Column(Integer, nullable=False)
+
+class StudyLog(Base):
+    __tablename__ = 'studylog'
+    id = Column(Integer, primary_key=True)
+    date = Column(Date, nullable=False, index=True)
+    topic_id = Column(Integer, ForeignKey('topic.id'), nullable=False, index=True)
+    minutes = Column(Integer, nullable=False)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="flex">
+  <div id="sidebar" class="w-1/4 border-r p-2"></div>
+  <div id="main" class="flex-1 p-2"></div>
+
+  <script type="text/babel">
+    const api = async (url, opts) => fetch(url, opts).then(r => r.json());
+
+    function Bar({label, value}) {
+      const width = value == null ? 0 : value * 100;
+      return <div className="my-2"><div>{label}: {value == null ? 'n/a' : (value*100).toFixed(0)+'%'}</div><div className="bg-gray-200 h-4"><div className="bg-blue-500 h-4" style={{width: width+'%'}}></div></div></div>;
+    }
+
+    function SessionTable({rows}) {
+      return <table className="min-w-full text-sm"><thead><tr><th>Date</th><th>Total</th><th>Correct</th></tr></thead><tbody>{rows.map((r,i)=><tr key={i}><td>{r.date}</td><td>{r.q_total}</td><td>{r.q_correct}</td></tr>)}</tbody></table>;
+    }
+
+    function App() {
+      const [topics,setTopics] = React.useState([]);
+      const [current,setCurrent] = React.useState(null);
+      const [from,setFrom] = React.useState('');
+      const [to,setTo] = React.useState('');
+      const [stats,setStats] = React.useState({});
+      const [sessions,setSessions] = React.useState([]);
+
+      React.useEffect(()=>{ api('/topics').then(setTopics); },[]);
+
+      React.useEffect(()=>{
+        if(current && from && to){
+          api(`/stats?topic_id=${current}&from_date=${from}&to_date=${to}`).then(setStats);
+          api(`/sessions?topic_id=${current}&from_date=${from}&to_date=${to}`).then(setSessions);
+        }
+      },[current,from,to]);
+
+      const renderTree = (nodes) => nodes.map(n => (
+        <div key={n.id} className="ml-2">
+          <div className="cursor-pointer text-blue-600" onClick={()=>setCurrent(n.id)}>{n.name}</div>
+          {n.children && n.children.length>0 && renderTree(n.children)}
+        </div>
+      ));
+
+      return (
+        <div className="flex w-full">
+          <div className="w-1/4 border-r p-2 overflow-y-auto" id="sidebar">
+            {renderTree(topics)}
+          </div>
+          <div className="flex-1 p-4" id="main">
+            <div className="flex space-x-2 mb-2">
+              <input type="date" value={from} onChange={e=>setFrom(e.target.value)} />
+              <input type="date" value={to} onChange={e=>setTo(e.target.value)} />
+            </div>
+            <Bar label="Accuracy" value={stats.accuracy} />
+            <Bar label="Study" value={stats.studyTime ? stats.studyTime/60 : 0} />
+            <Bar label="Progress" value={stats.progress} />
+            <SessionTable rows={sessions} />
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<App/>, document.getElementById('main'));
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with SQLite models for Topic, Session and StudyLog
- expose minimal REST endpoints for topics, sessions, study logs and stats
- add a simple React+Tailwind frontend to display progress bars and session table
- document how to run the server and open the frontend

## Testing
- `python3 -m py_compile backend/*.py`
- `uvicorn backend.main:app --port 8000 --reload` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_683f76f9470c832983f38805274bb4fe